### PR TITLE
Feature/screen text sink

### DIFF
--- a/scripts/library/eaw-log/sinks/screen-text.lua
+++ b/scripts/library/eaw-log/sinks/screen-text.lua
@@ -1,0 +1,23 @@
+return {
+    __important = true,
+    __id = "screen-text",
+    __has_character_limit = false,
+    __event = nil,
+    __trigger_name = nil,
+    __display_time = 5,
+    with_event = function(self, event, trigger_name)
+        self.__event = event
+        self.__trigger_name = trigger_name
+        return self
+    end,
+    with_display_time = function(self, time)
+        self.__display_time = time
+        return self
+    end,
+    __log = function(self, message)
+        local msg = tostring(message)
+        self.__event.Set_Reward_Parameter(0, msg)
+        self.__event.Set_Reward_Parameter(1, tostring(self.__display_time))
+        Story_Event(self.__trigger_name)
+    end
+}

--- a/scripts/library/eaw-log/sinks/screen-text.lua
+++ b/scripts/library/eaw-log/sinks/screen-text.lua
@@ -14,6 +14,10 @@ return {
         self.__display_time = time
         return self
     end,
+    with_character_limit_enabled = function (self, enable)
+        self.__has_character_limit = enable
+        return self
+    end,
     __log = function(self, message)
         if not self.__event or not self.__trigger_name then
             return

--- a/scripts/library/eaw-log/sinks/screen-text.lua
+++ b/scripts/library/eaw-log/sinks/screen-text.lua
@@ -1,7 +1,7 @@
 return {
     __important = true,
     __id = "screen-text",
-    __has_character_limit = false,
+    __has_character_limit = true,
     __event = nil,
     __trigger_name = nil,
     __display_time = 5,

--- a/scripts/library/eaw-log/sinks/screen-text.lua
+++ b/scripts/library/eaw-log/sinks/screen-text.lua
@@ -15,6 +15,9 @@ return {
         return self
     end,
     __log = function(self, message)
+        if not self.__event or not self.__trigger_name then
+            return
+        end
         local msg = tostring(message)
         self.__event.Set_Reward_Parameter(0, msg)
         self.__event.Set_Reward_Parameter(1, tostring(self.__display_time))


### PR DESCRIPTION
Usage:
```lua
local plot = Get_Story_Plot("STORY_SANDBOX_27_UNDERWORLD.XML")
local screen_text = plot.Get_Event("Generic_Screen_Text")
local screen_text_sink = require("eaw-log/sinks/screen-text")
                           :with_event(screen_text, "GENERIC_SCREEN_TEXT")
                           :with_character_limit_enabled(false)

Logger = require("eaw-log/logger")
           :with_sink(screen_text_sink)
           :with_log_level(3)
```

The sink allows turning off the character limit. Logging an error in debug mode will crash the game, but works fine in the regular build. I think this is because `DumpCallStack()` triggers the report upload dialog in official PG debug builds, which is not present in the public debug build.